### PR TITLE
Change test to have parse_url failed on negative port number

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -130,7 +130,7 @@ class UriTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to parse URI');
 
-        new Uri('//example.com:0');
+        new Uri('//example.com:-1');
     }
 
     public function testSchemeMustHaveCorrectType(): void


### PR DESCRIPTION
## Description
In PHP 7.14 `parse_url` behavior has changed. When showing port number at 0, it will not failed -> https://bugs.php.net/bug.php?id=80266
But this library still raising error when checking port manually

## Changelist
- Change unit test for using negative port number