### PR TITLE
fix: use expectExceptionMessageMatches for multiple error messages

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -139,7 +139,7 @@ MESSAGE);
     public function testNetworkExceptionBadURL(): void
     {
         $this->expectException(NetworkException::class);
-        $this->expectExceptionMessage('Could not resolve host: bad-example.com');
+        $this->expectExceptionMessageMatches('/Could not resolve host: bad-example\.com|Failed to connect to bad-example\.com port 443/');
 
         $client = new Client();
         $client->sendRequest(new Request('GET', $this->badURL));


### PR DESCRIPTION
## Description
Because error message is now different with php, I change how the exception message is catched for that specific test: `testNetworkExceptionBadURL`

## Changelist
- use `expectExceptionMessageMatches` instead of `expectExceptionMessage` for `testNetworkExceptionBadURL`