### PR TITLE
fix: update error handling in Stream::getContents()

### DIFF
--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -61,7 +61,9 @@ class StreamTest extends TestCase
         $this->expectExceptionMessage('Unable to read stream contents');
 
         $stream = Stream::create($handle);
+
         \fclose($handle);
+
         $stream->getContents();
     }
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -53,6 +53,18 @@ class StreamTest extends TestCase
         static::assertSame('', $stream->getContents());
     }
 
+    public function testGetsContentsRaiseException(): void
+    {
+        $handle = \fopen(\tempnam(\sys_get_temp_dir(), 'rancoud/http'), 'r+');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to read stream contents');
+
+        $stream = Stream::create($handle);
+        \fclose($handle);
+        $stream->getContents();
+    }
+
     public function testChecksEof(): void
     {
         $handle = \fopen('php://temp', 'w+');


### PR DESCRIPTION
## Description
Related to that Pull Request https://github.com/Nyholm/psr7/pull/252

> The current implementation of stream_get_contents() swallows errors, leading to issues like https://github.com/symfony/symfony/issues/52490, where errors reported by the stream layer aren't propagated to user-land.

> This is even in the C source:
> https://github.com/php/php-src/blob/311cae03e730c76aed343312319ed8cf1c37ade0/main/streams/streams.c#L1512

## Changelist
- Update `Stream::getContents()`
- Add tests