### PR TITLE
chore: update phpcs rules

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -20,6 +20,7 @@ $rules = [
         'spacing' => 'one'
     ],
     'declare_strict_types'        => true,
+    'get_class_to_class_keyword'  => false,
     'global_namespace_import'     => false,
     'linebreak_after_opening_tag' => true,
     'mb_str_functions'            => false, // turn off because of PHP 8.4
@@ -28,21 +29,22 @@ $rules = [
             '@all'
         ]
     ],
-    'no_php4_constructor'                   => true,
-    'no_superfluous_phpdoc_tags'            => false,
-    'no_unreachable_default_argument_value' => true,
-    'no_useless_else'                       => true,
-    'no_useless_return'                     => true,
-    'ordered_imports'                       => true,
-    'php_unit_strict'                       => true,
-    'phpdoc_order'                          => true,
-    'semicolon_after_instruction'           => true,
-    'single_import_per_statement'           => false,
-    'strict_comparison'                     => true,
-    'strict_param'                          => true,
-    'single_line_throw'                     => false,
-    'trailing_comma_in_multiline'           => false,
-    'yoda_style'                            => [
+    'no_php4_constructor'                              => true,
+    'no_superfluous_phpdoc_tags'                       => false,
+    'no_unreachable_default_argument_value'            => true,
+    'no_useless_else'                                  => true,
+    'no_useless_return'                                => true,
+    'nullable_type_declaration_for_default_null_value' => true,
+    'ordered_imports'                                  => true,
+    'php_unit_strict'                                  => true,
+    'phpdoc_order'                                     => true,
+    'semicolon_after_instruction'                      => true,
+    'single_import_per_statement'                      => false,
+    'strict_comparison'                                => true,
+    'strict_param'                                     => true,
+    'single_line_throw'                                => false,
+    'trailing_comma_in_multiline'                      => false,
+    'yoda_style'                                       => [
         'equal'            => false,
         'identical'        => false,
         'less_and_greater' => false


### PR DESCRIPTION
# Description
Add rule `nullable_type_declaration_for_default_null_value` to avoid deprecated error with PHP 8.4.
Add rule `get_class_to_class_keyword` to avoid changes due to `nullable_type_declaration_for_default_null_value` rule.