### PR TITLE
chore: update tests for phpunit 10 and 11

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests;
 
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use Rancoud\Http\Message\Factory\Factory;
@@ -69,6 +70,7 @@ class FactoryTest extends TestCase
     }
 
     /** @runInSeparateProcess  */
+    #[RunInSeparateProcess]
     public function testCreateServerRequestFromGlobalsWithRequestMethod(): void
     {
         $_SERVER = \array_merge($_SERVER, ['REQUEST_METHOD' => 'POST']);
@@ -77,6 +79,7 @@ class FactoryTest extends TestCase
     }
 
     /** @runInSeparateProcess  */
+    #[RunInSeparateProcess]
     public function testCreateServerRequestFromGlobalsWithoutRequestMethod(): void
     {
         $r = (new Factory())->createServerRequestFromGlobals();
@@ -84,6 +87,7 @@ class FactoryTest extends TestCase
     }
 
     /** @runInSeparateProcess  */
+    #[RunInSeparateProcess]
     public function testCreateServerRequestFromGlobalsFakeNginx(): void
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-gb,en;q=0.5';

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,6 +2,9 @@
 
 namespace tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use Rancoud\Http\Message\Factory\Factory;
@@ -10,6 +13,7 @@ use Rancoud\Http\Message\Response;
 /**
  * @backupGlobals disabled
  */
+#[PreserveGlobalState(false)]
 class ResponseTest extends TestCase
 {
     public function testDefaultConstructor(): void
@@ -258,7 +262,7 @@ class ResponseTest extends TestCase
         static::assertSame($r, $r->withoutHeader('foo'));
     }
 
-    public function trimmedHeaderValues(): array
+    public static function trimmedHeaderValues(): array
     {
         return [
             [new Response(200, ['OWS' => " \t \tFoo\t \t "])],
@@ -353,6 +357,7 @@ class ResponseTest extends TestCase
      *
      * @param Response $r
      */
+    #[DataProvider('trimmedHeaderValues')]
     public function testHeaderValuesAreTrimmed(Response $r): void
     {
         static::assertSame(['OWS' => ['Foo']], $r->getHeaders());
@@ -363,6 +368,7 @@ class ResponseTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    #[RunInSeparateProcess]
     public function testSend(): void
     {
         $r = new Response(

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Http\Message\Factory\Factory;
 use Rancoud\Http\Message\ServerRequest;
@@ -12,7 +13,7 @@ use Rancoud\Http\Message\Uri;
 
 class ServerRequestTest extends TestCase
 {
-    public function dataNormalizeFiles(): array
+    public static function dataNormalizeFiles(): array
     {
         return [
             'Single file' => [
@@ -269,6 +270,7 @@ class ServerRequestTest extends TestCase
      * @param $files
      * @param $expected
      */
+    #[DataProvider('dataNormalizeFiles')]
     public function testNormalizeFiles($files, $expected): void
     {
         $result = (new Factory())
@@ -286,7 +288,7 @@ class ServerRequestTest extends TestCase
         (new Factory())->createServerRequestFromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], [], ['test' => 'something']);
     }
 
-    public function dataGetUriFromGlobals(): array
+    public static function dataGetUriFromGlobals(): array
     {
         $server = [
             'PHP_SELF'             => '/blog/article.php',
@@ -353,6 +355,7 @@ class ServerRequestTest extends TestCase
      * @param $expected
      * @param $serverParams
      */
+    #[DataProvider('dataGetUriFromGlobals')]
     public function testGetUriFromGlobals($expected, $serverParams): void
     {
         static::assertEqualsCanonicalizing(new Uri($expected), (new Factory())->createUriFromArray($serverParams));

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -2,6 +2,7 @@
 
 namespace tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Http\Message\Stream;
 use Rancoud\Http\Message\UploadedFile;
@@ -24,7 +25,7 @@ class UploadedFileTest extends TestCase
         }
     }
 
-    public function invalidStreams(): array
+    public static function invalidStreams(): array
     {
         return [
             'null'   => [null],
@@ -42,6 +43,7 @@ class UploadedFileTest extends TestCase
      *
      * @param $streamOrFile
      */
+    #[DataProvider('invalidStreams')]
     public function testRaisesExceptionOnInvalidStreamOrFile($streamOrFile): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -50,7 +52,7 @@ class UploadedFileTest extends TestCase
         new UploadedFile($streamOrFile, 0, \UPLOAD_ERR_OK);
     }
 
-    public function invalidErrorStatuses(): array
+    public static function invalidErrorStatuses(): array
     {
         return [
             'negative' => [-1],
@@ -63,6 +65,7 @@ class UploadedFileTest extends TestCase
      *
      * @param $status
      */
+    #[DataProvider('invalidErrorStatuses')]
     public function testRaisesExceptionOnInvalidErrorStatus($status): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -113,7 +116,7 @@ class UploadedFileTest extends TestCase
         static::assertSame($stream->__toString(), \file_get_contents($to));
     }
 
-    public function invalidMovePaths(): array
+    public static function invalidMovePaths(): array
     {
         return [
             'empty'  => [''],
@@ -125,6 +128,7 @@ class UploadedFileTest extends TestCase
      *
      * @param $path
      */
+    #[DataProvider('invalidMovePaths')]
     public function testMoveRaisesExceptionForInvalidPath($path): void
     {
         $stream = Stream::create('Foo bar!');
@@ -165,7 +169,7 @@ class UploadedFileTest extends TestCase
         $upload->getStream();
     }
 
-    public function nonOkErrorStatus(): array
+    public static function nonOkErrorStatus(): array
     {
         return [
             'UPLOAD_ERR_INI_SIZE'   => [\UPLOAD_ERR_INI_SIZE],
@@ -183,6 +187,7 @@ class UploadedFileTest extends TestCase
      *
      * @param $status
      */
+    #[DataProvider('nonOkErrorStatus')]
     public function testConstructorDoesNotRaiseExceptionForInvalidStreamWhenErrorStatusPresent($status): void
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
@@ -194,6 +199,7 @@ class UploadedFileTest extends TestCase
      *
      * @param $status
      */
+    #[DataProvider('nonOkErrorStatus')]
     public function testMoveToRaisesExceptionWhenErrorStatusPresent($status): void
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
@@ -207,6 +213,7 @@ class UploadedFileTest extends TestCase
      *
      * @param $status
      */
+    #[DataProvider('nonOkErrorStatus')]
     public function testGetStreamRaisesExceptionWhenErrorStatusPresent($status): void
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Rancoud\Http\Message\Uri;
 
@@ -53,6 +54,7 @@ class UriTest extends TestCase
      *
      * @param $input
      */
+    #[DataProvider('getValidUris')]
     public function testValidUrisStayValid($input): void
     {
         $uri = new Uri($input);
@@ -60,7 +62,7 @@ class UriTest extends TestCase
         static::assertSame($input, (string) $uri);
     }
 
-    public function getValidUris(): array
+    public static function getValidUris(): array
     {
         return [
             ['urn:path-rootless'],
@@ -94,6 +96,7 @@ class UriTest extends TestCase
      *
      * @param $invalidUri
      */
+    #[DataProvider('getInvalidUris')]
     public function testInvalidUrisThrowException($invalidUri): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -102,7 +105,7 @@ class UriTest extends TestCase
         new Uri($invalidUri);
     }
 
-    public function getInvalidUris(): array
+    public static function getInvalidUris(): array
     {
         return [
             // parse_url() requires the host component which makes sense for http(s)
@@ -313,7 +316,7 @@ class UriTest extends TestCase
         static::assertSame('', $uri->getAuthority());
     }
 
-    public function uriComponentsEncodingProvider(): array
+    public static function uriComponentsEncodingProvider(): array
     {
         $unreserved = 'a-zA-Z0-9.-_~!$&\'()*+,;=:@';
 
@@ -344,6 +347,7 @@ class UriTest extends TestCase
      * @param $fragment
      * @param $output
      */
+    #[DataProvider('uriComponentsEncodingProvider')]
     public function testUriComponentsGetEncodedProperly($input, $path, $query, $fragment, $output): void
     {
         $uri = new Uri($input);


### PR DESCRIPTION
# Description
Update tests to avoid deprecations and failed tests by using attributes and static dataprovider.